### PR TITLE
fix(build): add Linux aarch64 wheel support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
 
     steps:
       - name: Checkout repository
@@ -29,10 +29,16 @@ jobs:
       - name: Install build tools
         run: pip install cibuildwheel twine
 
-      - name: Build sdist and wheels
+      - name: Build wheels
         run: cibuildwheel --output-dir wheelhouse
         env:
           MACOSX_DEPLOYMENT_TARGET: "11.0"
+
+      - name: Build sdist
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          pip install build
+          python -m build --sdist --outdir wheelhouse
 
       - name: Check package metadata
         run: python -m twine check wheelhouse/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include_directories(fasttext)
 if(WIN32)
     set(CMAKE_CXX_FLAGS " -std=c++17 -funroll-loops -O3")
 else()
-    set(CMAKE_CXX_FLAGS " -pthread -std=c++17 -funroll-loops -O3 -march=native")
+    set(CMAKE_CXX_FLAGS " -pthread -std=c++17 -funroll-loops -O3")
 endif()
 
 set(HEADER_FILES

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #
 
 CXX = c++
-CXXFLAGS = -pthread -std=c++17 -march=native
+CXXFLAGS = -pthread -std=c++17 -funroll-loops -O3
 OBJS = args.o autotune.o matrix.o dictionary.o loss.o productquantizer.o densematrix.o quantmatrix.o vector.o model.o utils.o meter.o fasttext.o
 INCLUDES = -I.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ test-extras = ["test"]
 test-command = "pytest {project}"
 build-verbosity = 1
 
+[tool.cibuildwheel.linux]
+archs = ["auto"]
+
 [tool.cibuildwheel.macos]
 archs = ["arm64", "x86_64", "universal2"]
 

--- a/setup.py
+++ b/setup.py
@@ -77,13 +77,6 @@ ext_modules = [
             FASTTEXT_SRC,
         ],
         language="c++",
-        extra_compile_args=[
-            (
-                "-O0 -fno-inline -fprofile-arcs -pthread -march=native"
-                if coverage
-                else "-O3 -funroll-loops -pthread -march=native"
-            )
-        ],
     ),
 ]
 
@@ -118,8 +111,8 @@ class BuildExt(build_ext):
     """A custom build extension for adding compiler-specific options."""
 
     c_opts = {
-        "msvc": ["/EHsc"],
-        "unix": [],
+        "msvc": ["/EHsc", "/O2"],
+        "unix": ["-O3", "-funroll-loops", "-pthread"],
     }
 
     def build_extensions(self):
@@ -144,6 +137,8 @@ class BuildExt(build_ext):
         extra_link_args = []
 
         if coverage:
+            opts = [o for o in opts if o not in ("-O3", "-funroll-loops")]
+            opts += ["-O0", "-fno-inline", "-fprofile-arcs"]
             coverage_option = "--coverage"
             opts.append(coverage_option)
             extra_link_args.append(coverage_option)


### PR DESCRIPTION
Enable linux arm64 wheel builds so that `pip install fasttext-community` works natively on arm-based instance like aws graviton

